### PR TITLE
Add an "mtls" mode for connection.

### DIFF
--- a/cmd/channelz.go
+++ b/cmd/channelz.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
-	"github.com/grpc-ecosystem/grpcdebug/cmd/transport"
-	"github.com/grpc-ecosystem/grpcdebug/cmd/verbose"
+	"github.com/hamishimac/grpcdebug/cmd/transport"
+	"github.com/hamishimac/grpcdebug/cmd/verbose"
 	"github.com/spf13/cobra"
 	zpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"runtime"
 
-	"github.com/grpc-ecosystem/grpcdebug/cmd/verbose"
+	"github.com/hamishimac/grpcdebug/cmd/verbose"
 	"gopkg.in/yaml.v2"
 )
 

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -20,6 +20,9 @@ const (
 	// TypeTLS is the TLS security mode, which requires caller to provide
 	// credentials to connect to peer
 	TypeTLS = "tls"
+	// TypeMTLS is the mutual TLS security mode.  For this mode the credentials
+	// supplied must be a certificate file, a key file, and a certificate-trust file.
+	TypeMTLS = "mtls"
 )
 
 // The environment variable name of getting the server configs
@@ -30,6 +33,8 @@ type ServerConfig struct {
 	RealAddress        string       `yaml:"real_address"`
 	Security           SecurityType `yaml:"security"`
 	CredentialFile     string       `yaml:"credential_file"`
+	KeyFile            string       `yaml:"key_file"`
+	TrustFile          string       `yaml:"trust_file"`
 	ServerNameOverride string       `yaml:"server_name_override"`
 }
 

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/grpc-ecosystem/grpcdebug/cmd/transport"
+	"github.com/hamishimac/grpcdebug/cmd/transport"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/grpc-ecosystem/grpcdebug/cmd/config"
-	"github.com/grpc-ecosystem/grpcdebug/cmd/transport"
-	"github.com/grpc-ecosystem/grpcdebug/cmd/verbose"
+	"github.com/hamishimac/grpcdebug/cmd/config"
+	"github.com/hamishimac/grpcdebug/cmd/transport"
+	"github.com/hamishimac/grpcdebug/cmd/verbose"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ import (
 )
 
 var verboseFlag, timestampFlag bool
-var address, security, credFile, serverNameOverride string
+var address, security, credFile, keyFile, trustFile, serverNameOverride string
 
 // The table formater
 var w = tabwriter.NewWriter(os.Stdout, 10, 0, 3, ' ', 0)
@@ -59,6 +59,12 @@ func initConfig() {
 	if credFile != "" {
 		c.CredentialFile = credFile
 	}
+	if keyFile != "" {
+		c.KeyFile = keyFile
+	}
+	if trustFile != "" {
+		c.TrustFile = trustFile
+	}
 	if serverNameOverride != "" {
 		c.ServerNameOverride = serverNameOverride
 	}
@@ -67,6 +73,20 @@ func initConfig() {
 		if c.CredentialFile == "" {
 			rootCmd.Usage()
 			log.Fatalf("Please specify credential file under [tls] mode.")
+		}
+	} else if security == "mtls" {
+		c.Security = config.TypeMTLS
+		if c.CredentialFile == "" {
+			rootCmd.Usage()
+			log.Fatalf("Please specify credential file under [mtls] mode.")
+		}
+		if c.KeyFile == "" {
+			rootCmd.Usage()
+			log.Fatalf("Please specify key file under [mtls] mode.")
+		}
+		if c.TrustFile == "" {
+			rootCmd.Usage()
+			log.Fatalf("Please specify trust file under [mtls] mode.")
 		}
 	} else if security != "insecure" {
 		rootCmd.Usage()
@@ -90,9 +110,11 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Print verbose information for debugging")
 	rootCmd.PersistentFlags().BoolVarP(&timestampFlag, "timestamp", "t", false, "Print timestamp as RFC3339 instead of human readable strings")
-	rootCmd.PersistentFlags().StringVar(&security, "security", "insecure", "Defines the type of credentials to use [tls, google-default, insecure]")
+	rootCmd.PersistentFlags().StringVar(&security, "security", "insecure", "Defines the type of credentials to use [tls, mtls, google-default, insecure]")
 	rootCmd.PersistentFlags().StringVar(&credFile, "credential_file", "", "Sets the path of the credential file; used in [tls] mode")
-	rootCmd.PersistentFlags().StringVar(&serverNameOverride, "server_name_override", "", "Overrides the peer server name if non empty; used in [tls] mode")
+	rootCmd.PersistentFlags().StringVar(&keyFile, "key_file", "", "Sets the path of the credential file; used in [tls] and [mtls] modes")
+	rootCmd.PersistentFlags().StringVar(&trustFile, "trust_file", "", "Sets the path of the credential file; used in [mtls] mode")
+	rootCmd.PersistentFlags().StringVar(&serverNameOverride, "server_name_override", "", "Overrides the peer server name if non empty; used in [tls] and [mtls] modes")
 }
 
 // Execute executes the root command.

--- a/cmd/transport/grpc.go
+++ b/cmd/transport/grpc.go
@@ -2,7 +2,11 @@ package transport
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"log"
+	"os"
 	"time"
 
 	csdspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
@@ -22,12 +26,40 @@ var healthClient healthpb.HealthClient
 
 const rpcTimeout = time.Second * 15
 
+func getMTLSConfig(c *config.ServerConfig) (*tls.Config, error) {
+	caCert, err := os.ReadFile(c.TrustFile)
+	if err != nil {
+		return nil, fmt.Errorf("error loading trust: %v", err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	cert, err := tls.LoadX509KeyPair(c.CredentialFile, c.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ServerName:   c.ServerNameOverride,
+		ClientCAs:    caCertPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		RootCAs:      caCertPool,
+	}, nil
+}
+
 // Connect connects to the service at address and creates stubs
 func Connect(c config.ServerConfig) {
 	verbose.Debugf("Connecting with %v", c)
 	var err error
 	var credOption grpc.DialOption
-	if c.CredentialFile != "" {
+	if c.Security == config.TypeMTLS {
+		tlsConfig, err := getMTLSConfig(&c)
+		if err != nil {
+			log.Fatalf("failed to create mtls credentials: %v", err)
+		}
+		credOption = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
+	} else if c.CredentialFile != "" {
 		cred, err := credentials.NewClientTLSFromFile(c.CredentialFile, c.ServerNameOverride)
 		if err != nil {
 			log.Fatalf("failed to create credential: %v", err)

--- a/cmd/transport/grpc.go
+++ b/cmd/transport/grpc.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	csdspb "github.com/envoyproxy/go-control-plane/envoy/service/status/v3"
-	"github.com/grpc-ecosystem/grpcdebug/cmd/config"
-	"github.com/grpc-ecosystem/grpcdebug/cmd/verbose"
+	"github.com/hamishimac/grpcdebug/cmd/config"
+	"github.com/hamishimac/grpcdebug/cmd/verbose"
 	"google.golang.org/grpc"
 	zpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	"google.golang.org/grpc/credentials"

--- a/cmd/xds.go
+++ b/cmd/xds.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/grpc-ecosystem/grpcdebug/cmd/transport"
+	"github.com/hamishimac/grpcdebug/cmd/transport"
 
 	adminpb "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
 	clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grpc-ecosystem/grpcdebug
+module github.com/hamishimac/grpcdebug
 
 go 1.23.0
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	cmd "github.com/grpc-ecosystem/grpcdebug/cmd"
+	cmd "github.com/hamishimac/grpcdebug/cmd"
 
 	// To parse Any protos, ProtoBuf requires the descriptors of the given message
 	// type to present in its descriptor pool. Otherwise, it will fail. Here we


### PR DESCRIPTION
This mode support mutual TLS on the GRPC transport connection. This "mtls" mode required a credential_file (certificate), a key_file (encryption key for the certificate), and a trust_file (the trust sources for the credential certificate).

These new files can be specified in a config file or on the command line.